### PR TITLE
Improve service worker error handling

### DIFF
--- a/plugins/pwa-register.client.js
+++ b/plugins/pwa-register.client.js
@@ -5,7 +5,7 @@ export default defineNuxtPlugin(() => {
   }
 
   // Handle service worker updates
-  function handleServiceWorkerUpdate(registration) {
+  const handleServiceWorkerUpdate = (registration) => {
     registration.addEventListener('updatefound', () => {
       const newWorker = registration.installing
 
@@ -56,7 +56,9 @@ export default defineNuxtPlugin(() => {
         message: error.message,
         fileName: error.fileName,
         lineNumber: error.lineNumber,
-        stack: error.stack
+        ...(process.env.NODE_ENV === 'development' && {
+          stack: error.stack
+        })
       }
 
       console.error('ServiceWorker registration failed:', errorDetails)


### PR DESCRIPTION
This pull request includes changes to the `handleServiceWorkerUpdate` function to improve error handling. The function now conditionally logs the error stack only in the development environment. This change ensures that error details are properly captured and logged when the service worker registration fails.

## Summary by Sourcery

Bug Fixes:
- Log the error stack when service worker registration fails only in the development environment.